### PR TITLE
No memmove

### DIFF
--- a/include/vidify_audiosync/cross_correlation.h
+++ b/include/vidify_audiosync/cross_correlation.h
@@ -4,10 +4,12 @@
 #include <stdlib.h>
 
 // Calculating the Pearson Correlation Coefficient between `source` and
-// `sample` starting at `start` until `end` applying the formula:
+// `sample` between two pointers, applying the formula:
 // https://en.wikipedia.org/wiki/Pearson_correlation_coefficient#For_a_sample
-double pearson_coefficient(double *source, double *sample, size_t start,
-                           size_t end);
+// This function will only work correctly if end - start != 0, and the arrays
+// passed by parameter are correctly allocated to the indicated size.
+double pearson_coefficient(double *source_start, double *source_end,
+                           double *sample_start, double *sample_end);
 
 // Calculating the cross-correlation between two signals `a` and `b`:
 //     xcross = ifft(fft(a) * conj(fft(b)))

--- a/src/cross_correlation.c
+++ b/src/cross_correlation.c
@@ -19,7 +19,7 @@ static pthread_mutex_t cc_mutex = PTHREAD_MUTEX_INITIALIZER;
 struct fftw_data {
     double *real;
     double complex *cpx;
-    size_t length;
+    size_t len;
 };
 
 // Concurrent implementation of the Fast Fourier Transform using FFTW.
@@ -30,7 +30,7 @@ static void *fft(void *arg) {
     // Initializing the plan: the only thread-safe call in FFTW is
     // fftw_execute, so the plan has to be created and destroyed with a lock.
     pthread_mutex_lock(&cc_mutex);
-    fftw_plan p = fftw_plan_dft_r2c_1d(data->length, data->real, data->cpx,
+    fftw_plan p = fftw_plan_dft_r2c_1d(data->len, data->real, data->cpx,
                                        FFTW_ESTIMATE);
     pthread_mutex_unlock(&cc_mutex);
 
@@ -46,33 +46,44 @@ static void *fft(void *arg) {
 
 
 // Calculating the Pearson Correlation Coefficient between `source` and
-// `sample` starting at `start` until `end` applying the formula:
+// `sample` between two pointers, applying the formula:
 // https://en.wikipedia.org/wiki/Pearson_correlation_coefficient#For_a_sample
 // This function will only work correctly if end - start != 0, and the arrays
 // passed by parameter are correctly allocated to the indicated size.
-double pearson_coefficient(double *source, double *sample, size_t start,
-                           size_t end) {
+double pearson_coefficient(double *source_start, double *source_end,
+                           double *sample_start, double *sample_end) {
     // 1. The average for both datasets.
     double sum1 = 0.0;
     double sum2 = 0.0;
-    for (size_t i = start; i < end; ++i) {
-         sum1 += source[i];
-         sum2 += sample[i];
+    // Both segments have the same size but start at different indexes.
+    double *source_i = source_start;
+    double *sample_i = sample_start;
+    while (source_i != source_end) {
+         sum1 += *source_i;
+         sum2 += *sample_i;
+
+         source_i++;
+         sample_i++;
     }
-    double avg1 = sum1 / (end - start);
-    double avg2 = sum2 / (end - start);
+    double avg1 = sum1 / (source_end - source_start);
+    double avg2 = sum2 / (sample_end - sample_start);
 
     // 2. Applying the definition formula.
     double diff1, diff2;
     double diffprod = 0.0;
     double diff1_squared = 0.0;
     double diff2_squared = 0.0;
-    for (size_t i = start; i < end; ++i) {
-        diff1 = source[i] - avg1;
-        diff2 = sample[i] - avg2;
+    source_i = source_start;
+    sample_i = sample_start;
+    while (source_i != source_end) {
+        diff1 = *source_i - avg1;
+        diff2 = *sample_i - avg2;
         diffprod += diff1 * diff2;
         diff1_squared += diff1 * diff1;
         diff2_squared += diff2 * diff2;
+
+        source_i++;
+        sample_i++;
     }
 
     return diffprod / sqrt(diff1_squared * diff2_squared);
@@ -95,13 +106,13 @@ double pearson_coefficient(double *source, double *sample, size_t start,
 //
 // In case of error, the function returns -1.
 int cross_correlation(double *source, double *input_sample,
-                      const size_t sample_length, long int *displacement,
+                      const size_t sample_len, long *lag,
                       double *coefficient) {
     double *sample = NULL;
     double *results = NULL;
     double complex *arr1 = NULL;
     double complex *arr2 = NULL;
-    const size_t length = sample_length * 2;
+    const size_t source_len = sample_len * 2;
     int ret = -1;
 
     // Only the sample needs to be zero-padded, since the cross correlation
@@ -111,28 +122,28 @@ int cross_correlation(double *source, double *input_sample,
     // Note: fftw_alloc_* uses fftw_malloc, which is an equivalent of running
     // malloc + memalign. This means that it may also return NULL in case of
     // error.
-    sample = fftw_alloc_real(length);
+    sample = fftw_alloc_real(source_len);
     if (sample == NULL) {
         perror("audiosync: sample fftw_alloc_real failed");
         goto finish;
     }
-    memcpy(sample, input_sample, sample_length * sizeof(*sample));
-    memset(sample + sample_length, 0,
-           (length - sample_length) * sizeof(*sample));
+    memcpy(sample, input_sample, sample_len * sizeof(*sample));
+    memset(sample + sample_len, 0,
+           (source_len - sample_len) * sizeof(*sample));
 
 #ifdef DEBUG
     // Plotting the output with gnuplot
     fprintf(stderr, "audiosync: Saving initial plot to '%ld_original.png'\n",
-            length);
+            source_len);
     FILE *gnuplot = popen("gnuplot", "w");
     fprintf(gnuplot, "set term 'png'\n");
-    fprintf(gnuplot, "set output 'images/%ld_original.png'\n", length);
+    fprintf(gnuplot, "set output 'images/%ld_original.png'\n", source_len);
     fprintf(gnuplot, "plot '-' with lines title 'sample', '-' with lines"
             " title 'source'\n");
-    for (size_t i = 0; i < length; ++i)
+    for (size_t i = 0; i < source_len; ++i)
         fprintf(gnuplot, "%f\n", source[i]);
     fprintf(gnuplot, "e\n");
-    for (size_t i = 0; i < length; ++i)
+    for (size_t i = 0; i < source_len; ++i)
         fprintf(gnuplot, "%f\n", sample[i]);
     fprintf(gnuplot, "e\n");
     fflush(gnuplot);
@@ -144,18 +155,18 @@ int cross_correlation(double *source, double *input_sample,
 
     // Getting the complex results from both FFT. The output length for the
     // complex numbers is n/2+1.
-    const size_t cpx_length = (length / 2) + 1;
-    arr1 = fftw_alloc_complex(cpx_length);
+    const size_t cpx_len = (source_len / 2) + 1;
+    arr1 = fftw_alloc_complex(cpx_len);
     if (arr1 == NULL) {
         perror("audiosync: arr1 fftw_alloc_real failed");
         goto finish;
     }
-    arr2 = fftw_alloc_complex(cpx_length);
+    arr2 = fftw_alloc_complex(cpx_len);
     if (arr2 == NULL) {
         perror("audiosync: arr2 fftw_alloc_real failed");
         goto finish;
     }
-    results = fftw_alloc_real(length);
+    results = fftw_alloc_real(source_len);
     if (results == NULL) {
         perror("audiosync: results fftw_alloc_real failed");
         goto finish;
@@ -166,12 +177,12 @@ int cross_correlation(double *source, double *input_sample,
     struct fftw_data fft1_data = {
         .real = source,
         .cpx = arr1,
-        .length = length,
+        .len = source_len,
     };
     struct fftw_data fft2_data = {
         .real = sample,
         .cpx = arr2,
-        .length = length,
+        .len = source_len,
     };
     if (pthread_create(&fft1_th, NULL, &fft, (void *) &fft1_data) < 0) {
         perror("audiosync: pthread_create for fft1_th failed");
@@ -191,71 +202,74 @@ int cross_correlation(double *source, double *input_sample,
     }
 
     // Product of fft1 * conj(fft2), saved in the first array.
-    for (size_t i = 0; i < cpx_length; ++i)
+    for (size_t i = 0; i < cpx_len; ++i)
         arr1[i] *= conj(arr2[i]);
 
     // And calculating the ifft. The size of the results is going to be the
     // original length again.
-    fftw_plan p = fftw_plan_dft_c2r_1d(length, arr1, results, FFTW_ESTIMATE);
+    fftw_plan p = fftw_plan_dft_c2r_1d(source_len, arr1, results, FFTW_ESTIMATE);
     fftw_execute(p);
     fftw_destroy_plan(p);
 
     // Getting the results: the index of the maximum value is the desired lag.
     double abs_result;
     double max = results[0];
-    long int lag = 0;
-    for (size_t i = 1; i < length; ++i) {
+    *lag = 0;
+    for (size_t i = 1; i < source_len; ++i) {
         abs_result = fabs(results[i]);
         if (abs_result > max) {
             max = abs_result;
-            lag = i;
+            *lag = i;
         }
     }
 
     // If the lag is greater than the input array itself, it means that the
-    // displacement that has to be performed is to the left, and otherwise
+    // sample displacement has to be performed is to the left, and otherwise
     // to the right.
-    size_t shift_start = 0;
-    size_t shift_end = sample_length;
-    if (lag >= (long int) sample_length) {
-        // Performing the displacement to the left
-        lag = (long int) sample_length - (lag % (long int) sample_length);
-        shift_end = (sample_length - lag);
-        memmove(sample, sample + lag, sizeof(double) * shift_end);
-        *displacement = -lag;
+    //
+    // The source size is twice the sample size, so if the sample is displaced
+    // to the right, no sample data will be lost, and the resulting size will
+    // be sample_len. But if the sample is moved to the left, some elements
+    // will be lost from it and thus, the resulting size will be
+    // sample_len - lag.
+    //
+    // Finally, the Pearson Correlation Coefficient is calculated with the
+    // resulting segment of data.
+    if (*lag >= (long) sample_len) {
+        // Displacing the sample to the left (lag is negative), final size
+        // is sample_len - lag.
+        *lag = (*lag % (long) sample_len) - (long) sample_len;
+        *coefficient = pearson_coefficient(source, source + *lag + sample_len,
+                                           sample - *lag, sample + sample_len);
     } else {
-        // Performing the displacement to the right
-        shift_start = lag;
-        memmove(sample + shift_start, sample, sizeof(double) * shift_end);
-        *displacement = lag;
+        // Displacing the sample to the right (lag is positive), final size
+        // is sample_len.
+        *coefficient = pearson_coefficient(source + *lag, source + *lag + sample_len,
+                                           sample, sample + sample_len);
     }
-
-    // Calculating the Pearson Correlation Coefficient to obtain the
-    // accuracy of the results.
-    *coefficient = pearson_coefficient(source, sample, shift_start, shift_end);
 
     // Checking that the resulting coefficient isn't NaN.
     if (*coefficient != *coefficient) goto finish;
 
     fprintf(stderr, "audiosync: %ld frames of delay with a confidence of %f\n",
-            *displacement, *coefficient);
+            *lag, *coefficient);
 
 #ifdef DEBUG
     fprintf(stderr, "audiosync: Result obtained in %f secs\n",
             (clock() - start) / (double) CLOCKS_PER_SEC);
 
     // Plotting the output with gnuplot
-    fprintf(stderr, "audiosync: Saving plot to '%ld.png'\n", length);
+    fprintf(stderr, "audiosync: Saving plot to '%ld.png'\n", source_len);
     gnuplot = popen("gnuplot", "w");
     fprintf(gnuplot, "set term 'png'\n");
-    fprintf(gnuplot, "set output 'images/%ld.png'\n", length);
+    fprintf(gnuplot, "set output 'images/%ld.png'\n", source_len);
     fprintf(gnuplot, "plot '-' with lines title 'sample', '-' with lines"
             " title 'source'\n");
-    for (size_t i = shift_start; i < shift_end; ++i)
+    for (size_t i = 0; i < sample_len; i++)
         fprintf(gnuplot, "%f\n", source[i]);
     fprintf(gnuplot, "e\n");
-    for (size_t i = shift_start; i < shift_end; ++i)
-        fprintf(gnuplot, "%f\n", sample[i]);
+    // for (double *i = sample_start; i < sample_end; i++)
+        // fprintf(gnuplot, "%f\n", *i);
     fprintf(gnuplot, "e\n");
     fflush(gnuplot);
     pclose(gnuplot);

--- a/src/cross_correlation.c
+++ b/src/cross_correlation.c
@@ -235,18 +235,25 @@ int cross_correlation(double *source, double *input_sample,
     //
     // Finally, the Pearson Correlation Coefficient is calculated with the
     // resulting segment of data.
+    double *source_start, *source_end, *sample_start, *sample_end;
     if (*lag >= (long) sample_len) {
         // Displacing the sample to the left (lag is negative), final size
         // is sample_len - lag.
         *lag = (*lag % (long) sample_len) - (long) sample_len;
-        *coefficient = pearson_coefficient(source, source + *lag + sample_len,
-                                           sample - *lag, sample + sample_len);
+        source_start = source;
+        source_end = source + *lag + sample_len;
+        sample_start = sample - *lag;
+        sample_end = sample + sample_len;
     } else {
         // Displacing the sample to the right (lag is positive), final size
         // is sample_len.
-        *coefficient = pearson_coefficient(source + *lag, source + *lag + sample_len,
-                                           sample, sample + sample_len);
+        source_start = source + *lag;
+        source_end = source + *lag + sample_len;
+        sample_start = sample;
+        sample_end = sample + sample_len;
     }
+    *coefficient = pearson_coefficient(source_start, source_end, sample_start,
+                                       sample_end);
 
     // Checking that the resulting coefficient isn't NaN.
     if (*coefficient != *coefficient) goto finish;
@@ -265,11 +272,11 @@ int cross_correlation(double *source, double *input_sample,
     fprintf(gnuplot, "set output 'images/%ld.png'\n", source_len);
     fprintf(gnuplot, "plot '-' with lines title 'sample', '-' with lines"
             " title 'source'\n");
-    for (size_t i = 0; i < sample_len; i++)
-        fprintf(gnuplot, "%f\n", source[i]);
+    for (double *i = source_start; i < source_end; i++)
+        fprintf(gnuplot, "%f\n", *i);
     fprintf(gnuplot, "e\n");
-    // for (double *i = sample_start; i < sample_end; i++)
-        // fprintf(gnuplot, "%f\n", *i);
+    for (double *i = sample_start; i < sample_end; i++)
+        fprintf(gnuplot, "%f\n", *i);
     fprintf(gnuplot, "e\n");
     fflush(gnuplot);
     pclose(gnuplot);

--- a/tests/test_cross_correlation.c
+++ b/tests/test_cross_correlation.c
@@ -71,8 +71,8 @@ int main() {
     assert(coef > MIN_CONFIDENCE);
 
     printf(">> Test 6\n");
-    double source6[] = { 0,0,0,0,0,1,2,3,4,1,2,3,4,0 };
-    double sample6[] = { 1,2,3,4,0,0,0 };
+    double source6[] = { 0,0,0,0,0,1,2,3,4,-1,-3,-5,0,0 };
+    double sample6[] = { 1,2,3,4,-1,-3,-5 };
     length = sizeof(sample6) / sizeof(*sample6);
     ret = cross_correlation(source6, sample6, length, &lag, &coef);
     printf("Returned %d: lag=%ld coef=%f\n", ret, lag, coef);

--- a/tests/test_pearson_coefficient.c
+++ b/tests/test_pearson_coefficient.c
@@ -13,38 +13,47 @@
 int main() {
     double ret;
     size_t len;
+    size_t lag;
 
     // Basic tests for identical source and sample.
+    // Test 1 simulates a displacement to the left.
     printf(">> Test 1\n");
     double source1[] = { 1.0,2.1,3.2,4.3,5.4,6.5,7.6,8.7,9.8,10.9 };
-    double sample1[] = { 1.0,2.1,3.2,4.3,5.4,6.5,7.6,8.7,9.8,10.9 };
-    len = sizeof(source1) / sizeof(*source1);
-    ret = pearson_coefficient(source1, sample1, 0, len);
-    printf("Returned %f between %ld and %ld\n", ret, 0L, len);
+    double sample1[] = { 0,0,1.0,2.1,3.2,4.3,5.4,6.5,7.6,8.7 };
+    len = sizeof(sample1) / sizeof(*sample1);
+    lag = -2;
+    ret = pearson_coefficient(source1, source1 + lag + len,
+                              sample1 - lag, sample1 + len);
+    printf("Returned %f\n", ret);
     assert(ret == 1.0);
-    ret = pearson_coefficient(source1, sample1, 0, 5);
-    printf("Returned %f between %ld and %ld\n", ret, 0L, 5L);
-    assert(ret == 1.0);
-    ret = pearson_coefficient(source1, sample1, 5, len);
-    printf("Returned %f between %ld and %ld\n", ret, 5L, len);
+
+    // Test 2 simulates a displacement to the right.
+    printf(">> Test 2\n");
+    double source2[] = { 0,0,0,0,100,200,300,400,500,600,700 };
+    double sample2[] = { 100,200,300,400,500 };
+    len = sizeof(sample2) / sizeof(*sample2);
+    lag = 4;
+    ret = pearson_coefficient(source2 + lag, source2 + lag + len,
+                              sample2, sample2 + len);
+    printf("Returned %f\n", ret);
     assert(ret == 1.0);
 
     // Testing negative linear correlation
-    printf(">> Test 2\n");
-    double source2[] = { 1,2,3,4 };
-    double sample2[] = { 4,3,2,1 };
-    len = sizeof(source2) / sizeof(*source2);
-    ret = pearson_coefficient(source2, sample2, 0, len);
+    printf(">> Test 3\n");
+    double source3[] = { 1,2,3,4 };
+    double sample3[] = { 4,3,2,1 };
+    len = sizeof(source3) / sizeof(*source3);
+    ret = pearson_coefficient(source3, source3 + len, sample3, sample3 + len);
     printf("Returned %f between %ld and %ld\n", ret, 0L, len);
     assert(ret == -1.0);
 
     // Testing that on error, NaN is returned (in this case, an array filled
     // with zeroes isn't defined in the Pearson Correlation Coefficient).
-    printf(">> Test 3\n");
-    double source3[] = { 1,2,3,4 };
-    double sample3[] = { 0,0,0,0 };
-    len = sizeof(source3) / sizeof(*source3);
-    ret = pearson_coefficient(source3, sample3, 0, len);
+    printf(">> Test 4\n");
+    double source4[] = { 1,2,3,4 };
+    double sample4[] = { 0,0,0,0 };
+    len = sizeof(source4) / sizeof(*source4);
+    ret = pearson_coefficient(source4, source4 + len, sample4, sample4 + len);
     printf("Returned %f between %ld and %ld\n", ret, 0L, len);
     assert(ret != ret);
 


### PR DESCRIPTION
This also fixes a bug I found when calculating the resulting segment. Originally, when the sample was displaced to the right, only `sample_len - lag` elements were compared to calculate the Pearson Correlation Coefficient. But knowing that the source length is twice the sample length, `sample_len` elements can be compared, since the remainder when displaced to the right is available in the source data.

It's explained in detail in the code.

See #31 for the changes related to performance and precision.